### PR TITLE
Potential fix for code scanning alert no. 8: Uncontrolled data used in path expression

### DIFF
--- a/scripts/import_day_yaml.py
+++ b/scripts/import_day_yaml.py
@@ -164,6 +164,16 @@ def import_day_file(path: Path, dry_run: bool = False) -> bool:
 
 
 def import_folder(folder: Path, dry_run: bool = False):
+    # Validate that folder is within DAY_FILES_DIR
+    try:
+        safe_root = DAY_FILES_DIR.resolve()
+        folder_path = folder.resolve()
+        if not str(folder_path).startswith(str(safe_root)):
+            logging.error(f"Folder '{folder}' is not within the allowed directory '{DAY_FILES_DIR}'. Aborting.")
+            return
+    except Exception as e:
+        logging.error(f"Could not resolve folder path: {e}")
+        return
     yaml_files = sorted(folder.glob("day_*.yaml"))
     success, failure = 0, 0
     for f in yaml_files:


### PR DESCRIPTION
Potential fix for [https://github.com/vaultman765/spiritual_formation_project/security/code-scanning/8](https://github.com/vaultman765/spiritual_formation_project/security/code-scanning/8)

To fix the problem, we should validate the user-provided folder path before using it to access files. The best approach is to define a safe root directory (e.g., `DAY_FILES_DIR` if appropriate) and ensure that the normalized folder path is contained within this root. This can be done by normalizing the path with `os.path.normpath` or `Path.resolve()`, and then checking that the resulting path starts with the safe root directory. If the check fails, the script should abort with an error message.

Specifically, in `import_folder(folder: Path, ...)`, before using `folder.glob`, we should:
- Normalize the folder path.
- Check that it is a subdirectory of the safe root (e.g., `DAY_FILES_DIR`).
- If not, log an error and abort.

We also need to ensure that the fix is applied in the main function, where the folder path is first received, or at the start of `import_folder`.

No new methods are needed, but we may need to import `os` or use `Path.resolve()` for normalization.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
