### PR TITLE
feat: add initial HTML structure for How to Pray guide

### DIFF
--- a/frontend/public/how-to-pray/card/index.html
+++ b/frontend/public/how-to-pray/card/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>How to Pray – Ignatian Mental Prayer (Beginner’s Guide)</title>
+  <meta name="description" content="A gentle, step-by-step guide to Ignatian mental prayer – clear, non-intimidating, and practical." />
+  <link rel="canonical" href="https://www.catholicmentalprayer.com/how-to-pray" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://www.catholicmentalprayer.com/how-to-pray" />
+  <meta property="og:title" content="How to Pray – Ignatian Mental Prayer (Beginner’s Guide)" />
+  <meta property="og:description" content="A gentle, step-by-step guide to Ignatian mental prayer – clear, non-intimidating, and practical." />
+  <meta property="og:image" content="https://www.catholicmentalprayer.com/images/how_to_pray/how_to_pray.jpg" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:image:alt" content="Hands in prayer with a rosary over Scripture" />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:site" content="@RCMentalPrayer" />
+  <meta name="twitter:title" content="How to Pray – Ignatian Mental Prayer (Beginner’s Guide)" />
+  <meta name="twitter:description" content="A gentle, step-by-step guide to Ignatian mental prayer – clear, non-intimidating, and practical." />
+  <meta name="twitter:image" content="https://www.catholicmentalprayer.com/images/how_to_pray/how_to_pray.jpg" />
+  <meta name="twitter:image:alt" content="Hands in prayer with a rosary over Scripture" />
+
+  <!-- Avoid SEO duplication -->
+  <meta name="robots" content="noindex,follow" />
+  <style>body{font-family:system-ui;display:grid;place-items:center;height:100dvh;margin:0;color:#eee;background:#2e1a49}</style>
+</head>
+<body>
+  <p><a href="https://www.catholicmentalprayer.com/how-to-pray" style="color:#f5d7a4">Continue to the How to Pray guide →</a></p>
+</body>
+</html>


### PR DESCRIPTION
This pull request adds a new HTML card page for the "How to Pray" guide. The page is designed for SEO and social media sharing, and includes a styled link directing users to the main guide.

New "How to Pray" card page:

* Added `frontend/public/how-to-pray/card/index.html` as a simple, styled HTML page with meta tags for SEO, Open Graph, and Twitter, and a canonical link to the main guide.