### PR TITLE
Potential fix for code scanning alert no. 40: Server-side request forgery

### DIFF
--- a/frontend/scripts/generate-sitemap.mjs
+++ b/frontend/scripts/generate-sitemap.mjs
@@ -7,7 +7,16 @@ import { readdir } from 'node:fs/promises';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SITE_URL = 'https://www.catholicmentalprayer.com';
-const API_URL = process.env.VITE_API_URL || 'https://api.catholicmentalprayer.com';
+// Only allow API_URL values from a verified allow-list to prevent SSRF
+const ALLOWED_API_URLS = [
+  'https://api.catholicmentalprayer.com',
+  // If you have staging/dev endpoints, add them here explicitly
+  // 'https://staging-api.catholicmentalprayer.com'
+];
+const ENV_API_URL = process.env.VITE_API_URL;
+const API_URL = (ENV_API_URL && ALLOWED_API_URLS.includes(ENV_API_URL))
+  ? ENV_API_URL
+  : 'https://api.catholicmentalprayer.com';
 
 
 /**


### PR DESCRIPTION
Potential fix for [https://github.com/vaultman765/spiritual_formation_project/security/code-scanning/40](https://github.com/vaultman765/spiritual_formation_project/security/code-scanning/40)

**General approach:**  
To fix this SSRF issue, restrict the use of `VITE_API_URL` to a pre-approved whitelist of API URLs, rather than using any arbitrary string from the environment. This allow-listing prevents an attacker from causing outbound connections to attacker-controlled or internal addresses. The code should assign the outgoing API URL only if the environment variable matches a value on this list; otherwise, it should default to the intended public API URL or fail gracefully.

**Best fix in place:**  
Edit the definition of `API_URL` so that if `process.env.VITE_API_URL` is provided, it must be present in a hardcoded list of safe URLs. If not, default to the production API URL. This should be implemented close to where `API_URL` is currently defined (line 10).

**Required additions:**  
- New constant (array or set) listing allowed URLs.
- Logic on line 10 to check against the allow-list.
- Optionally, log a warning or throw an error if a value is not in the allow-list.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
